### PR TITLE
删掉mysql jdbc.url中的"amp;",因为这个是xml中&的转义符配置方法，但在properties中不适用.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 #jdbc mysql \u786E\u4FDD\u6570\u636E\u5E93\u7F16\u7801\u4E3AUTF8\u5426\u5219\u4F1A\u6709\u4E71\u7801\u95EE\u9898
 #jdbc.driver=com.mysql.jdbc.Driver
-#jdbc.url=jdbc:mysql://localhost:3306/kad?useUnicode=true&amp;characterEncoding=utf-8
+#jdbc.url=jdbc:mysql://localhost:3306/kad?useUnicode=true&characterEncoding=utf-8
 #jdbc.username=root
 #jdbc.password=root
 #hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect


### PR DESCRIPTION
删掉mysql jdbc.url中的"amp;",因为这个是xml中&的转义符配置方法，但在properties中不适用.
Signed-off-by: Jacarri Chan 772929989@qq.com
