### PR TITLE
Tomcat启动冲突处理

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,12 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
             <version>2.7.6</version>
+            <exclusions>
+            	<exclusion>
+            		<artifactId>geronimo-servlet_3.0_spec</artifactId>
+            		<groupId>org.apache.geronimo.specs</groupId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
更新后，使用Tomcat6/7均无法启动，原因即cxf依赖冲突。
